### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pathfinder
 <p align="center">
-    <img src="Pathfinder.jpg" alt="Pathfinder" width="300"/>
+    <img src="https://i.imgur.com/TEDoP2L.jpeg" alt="Pathfinder" width="300"/>
 </p>
 
 Finds and outputs all API routes found in a .NET assembly in textual or JSON format.
@@ -28,7 +28,7 @@ dotnet build your-project
 pathfinder **/bin/**/yourdllname.dll -o Text
 ```
 
-![image](https://github.com/user-attachments/assets/adc9b60c-c991-46b0-b474-8de967666467)
+![image](https://i.imgur.com/2Oz4HJA.png)
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Finds and outputs all API routes found in a .NET assembly in textual or JSON for
 - .NET 7 or later installed (only for running CLI, not in your project)
 
 ## CLI
-- dotnet tool install -g Makspll.Pathfinder
+- `dotnet tool install -g Makspll.Pathfinder`
 
 # Usage
 ```
-dotnet tool run pathfinder --help
+pathfinder --help
 dotnet build your-project
-dotnet tool run pathfinder **/bin/**/yourdllname.dll -o Text
+pathfinder **/bin/**/yourdllname.dll -o Text
 ```
 
 ![image](https://github.com/user-attachments/assets/adc9b60c-c991-46b0-b474-8de967666467)

--- a/src/app/Pathfinder.csproj
+++ b/src/app/Pathfinder.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Makspll.Pathfinder</PackageId>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <Authors>Maksymilian Mozolewski</Authors>
     <Description>CLI used to find all API routes present in a .NET core/framework assembly.</Description>
     <PackageProjectUrl>https://github.com/makspll/Pathfinder</PackageProjectUrl>

--- a/src/app/Program.cs
+++ b/src/app/Program.cs
@@ -10,7 +10,6 @@ try
 }
 catch (Exception e)
 {
-    Console.WriteLine(e.Message);
     Environment.Exit(1);
 }
 

--- a/src/lib/PathfinderLib.csproj
+++ b/src/lib/PathfinderLib.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <PackageId>Makspll.PathfinderLib</PackageId>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <Authors>Maksymilian Mozolewski</Authors>
     <Description>The library behind the Pathfinder CLI with configurable discovery mechanisms.</Description>
     <PackageProjectUrl>https://github.com/makspll/Pathfinder</PackageProjectUrl>


### PR DESCRIPTION
- Fix typos
- Don't print error on parsing exception (CLI manages that itself)
- fix broken links