### PR TITLE
Fix assembly name not working correctly

### DIFF
--- a/src/lib/Pathfinder.cs
+++ b/src/lib/Pathfinder.cs
@@ -48,7 +48,7 @@ public class Pathfinder(IEnumerable<string> dllGlobs, string directory, string c
 
             var assembly = new Assembly
             {
-                Name = dll.Split('/').Last(),
+                Name = Path.GetFileNameWithoutExtension(dll),
                 Path = dll,
                 Controllers = controllers,
                 FrameworkVersion = query.DetectedFramework


### PR DESCRIPTION
- Probably because of slashes